### PR TITLE
Revert Minimum Swift Toolchain Version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:4.0
 
 import PackageDescription
 


### PR DESCRIPTION
Revert from 5.0 to 4.0 to be in sync with [Getting Started](https://github.com/PerfectlySoft/PerfectDocs/blob/master/guide/gettingStarted.md) Documentation. 